### PR TITLE
stale daemon pid fix; better pid file removals

### DIFF
--- a/dad
+++ b/dad
@@ -41,9 +41,16 @@ daemon_pid=/tmp/diana-daemon.pid
 
 case "$1" in
 	start)
+		# If diana daemon pid file is found
 		if [ -e "$daemon_pid" ] ; then
-			printf '%s\n' 'The daemon is already running.' >&2
-			exit 1
+			# remove pid file if referenced process id is not running
+			if ! ps -p $(cat "$daemon_pid") > /dev/null 2>&1 ; then
+	    			rm -f $daemon_pid
+	  		# otherwise just exit
+	  		else
+				printf '%s\n' 'The daemon is already running.' >&2
+				exit 1
+			fi
 		fi
 
 		XDG_DATA_HOME=${XDG_DATA_HOME:-${HOME}/.local/share}
@@ -62,7 +69,7 @@ case "$1" in
 
 		if [ $? -ne 0 ] ; then
 			printf '%s\n' 'The daemon failed to start.' >&2
-			rm "$daemon_pid"
+			rm -f "$daemon_pid"
 			exit 1
 		fi
 		;;
@@ -78,7 +85,7 @@ case "$1" in
 			printf '%s\n' 'Could not stop the daemon.' >&2
 			exit 1
 		else
-			rm "$daemon_pid"
+			rm -f "$daemon_pid"
 		fi
 		;;
 esac


### PR DESCRIPTION
### Issue

Trying to start the daemon with `dad start` **fails** if a stale pid file exists, such as when the `aria2c` process is killed, crashes, or if the system loses power.

### Changes

I tweaked the start block of the dad daemon script as follows:

* Checks for and cleans up a stale daemon pid file if its process is no longer running, then continues by starting daemon normally.
* Added `-f` parameters to all `rm` calls to make them more reliable (avoid any delete prompts from `rm`).

### Example

Start daemon:
```
./dad start
```

show its running pid:

```
cat /tmp/diana-daemon.pid
13960
```

Show running process from `ps`:

```
ps aux | grep -i aria2c | grep -v grep
admin    13960  0.0  0.2   9148  2456 ?        Ss   00:51   0:00 aria2c --daemon <....>
```
----
#### Process is killed, or system reboots, or loses power, etc.
----

```
kill -9 13960
```

Starting daemon now fails:

```
 ./dad start
The daemon is already running.
```

With my fixed version the script checks the pid and realizes its not running, cleans up the stale pid file, and then starts the daemon properly:

```
./dad start
```

I can double-check that the daemon is really running:

```
ps aux | grep -i aria2c | grep -v grep
admin    14237  0.0  0.2   9148  2456 ?        Ss   00:53   0:00 aria2c --daemon --enable-rpc ......
```

This matches the process id from the pid file:

```
cat /tmp/diana-daemon.pid
14237
```

All good!