### PR TITLE
Correct typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![diana] (https://github.com/baskerville/diana/raw/master/logo/diana-logo.jpg)
+![diana](https://github.com/baskerville/diana/raw/master/logo/diana-logo.jpg)
 
 ## Usage
 


### PR DESCRIPTION
A typo in the readme meant that the logo was not displayed. Just removing a space fixed it!